### PR TITLE
Remove redundant FixMap function

### DIFF
--- a/example-openai-compat/gen/go/proto/example/v1/examplev1mcp/example.pb.mcp.go
+++ b/example-openai-compat/gen/go/proto/example/v1/examplev1mcp/example.pb.mcp.go
@@ -73,7 +73,7 @@ func ForwardToConnectExampleServiceClient(s *mcpserver.MCPServer, client Connect
 		var req v1.CreateExampleRequest
 
 		message := request.Params.Arguments
-		runtime.FixMap(req.ProtoReflect().Descriptor(), message)
+		runtime.FixOpenAI(req.ProtoReflect().Descriptor(), message)
 
 		marshaled, err := json.Marshal(message)
 		if err != nil {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -149,7 +149,7 @@ func ForwardToConnect{{$key}}Client(s *mcpserver.MCPServer, client Connect{{$key
 
     message := request.Params.Arguments
     {{- if $.OpenAICompat }}
-    runtime.FixMap(req.ProtoReflect().Descriptor(), message)
+    runtime.FixOpenAI(req.ProtoReflect().Descriptor(), message)
     {{- end }}
 
     marshaled, err := json.Marshal(message)

--- a/pkg/runtime/fix.go
+++ b/pkg/runtime/fix.go
@@ -18,47 +18,10 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// ReplaceArrayWithMap replaces an array of key/value pairs with a proper map.
-// The generator can output a JSON schema, that describes protobuf maps as an array of key/value pairs,
-// because OpenAI does not support dynamic maps (additionalProperties).
-// This function here translates it back, before the generated code uses protojson.Unmarshal.
-func FixMap(descriptor protoreflect.MessageDescriptor, args map[string]any) {
-	var rewrite func(msg protoreflect.MessageDescriptor, path []string, obj map[string]any)
-
-	rewrite = func(msg protoreflect.MessageDescriptor, path []string, obj map[string]any) {
-		for i := 0; i < msg.Fields().Len(); i++ {
-			field := msg.Fields().Get(i)
-			name := string(field.Name())
-			currentPath := append(path, name)
-
-			if field.IsMap() {
-				if arr, ok := obj[name].([]any); ok {
-					m := make(map[string]any)
-					for _, e := range arr {
-						if pair, ok := e.(map[string]any); ok {
-							k, kOk := pair["key"].(string)
-							v, vOk := pair["value"]
-							if kOk && vOk {
-								m[k] = v
-							}
-						}
-					}
-					obj[name] = m
-				}
-			} else if field.Kind() == protoreflect.MessageKind {
-				if nested, ok := obj[name].(map[string]any); ok {
-					rewrite(field.Message(), currentPath, nested)
-				}
-			}
-		}
-	}
-
-	rewrite(descriptor, nil, args)
-}
 
 // FixOpenAI applies all OpenAI compatibility transformations to convert OpenAI-formatted JSON
 // back to standard protobuf-compatible JSON. This includes:
-// - Converting map arrays back to objects (FixMap)
+// - Converting map arrays back to objects
 // - Converting string representations back to proper JSON for google.protobuf.Value/ListValue/Struct
 func FixOpenAI(descriptor protoreflect.MessageDescriptor, args map[string]any) {
 	var rewrite func(msg protoreflect.MessageDescriptor, path []string, obj map[string]any)

--- a/pkg/runtime/fix_test.go
+++ b/pkg/runtime/fix_test.go
@@ -38,7 +38,7 @@ func TestFix(t *testing.T) {
 	err := json.Unmarshal([]byte(in), &inMap)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	FixMap(new(examplev1.CreateExampleRequest).ProtoReflect().Descriptor(), inMap)
+	FixOpenAI(new(examplev1.CreateExampleRequest).ProtoReflect().Descriptor(), inMap)
 
 	jzon, err := json.Marshal(inMap)
 	g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Summary
- Remove the redundant `FixMap` function since `FixOpenAI` provides all the same functionality plus additional OpenAI transformations
- Update all usage to consistently use `FixOpenAI` for comprehensive OpenAI compatibility handling
- Clean up generated code to use the unified function

## Test plan
- [x] All existing tests pass
- [x] Generated code compiles successfully
- [x] OpenAI compatibility functionality remains intact