### PR TITLE
generator: include errordetails in error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,10 @@ require (
 )
 
 require (
+	buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.34.2-20240917150400-3f349e63f44a.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/redpanda-data/common-go/api v0.0.0-20250801174835-9eea07f1ea06 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.34.2-20240917150400-3f349e63f44a.2 h1:JyGBchZNUPlQ7/qjieeKq/Cy+/i1vc0H+cIniGZNSFg=
+buf.build/gen/go/redpandadata/common/protocolbuffers/go v1.34.2-20240917150400-3f349e63f44a.2/go.mod h1:wThyg02xJx4K/DA5fg0QlKts8XVPyTT86JC8hPfEzno=
 connectrpc.com/connect v1.18.1 h1:PAg7CjSAGvscaf6YZKUefjoih5Z/qYkyaTrBW8xvYPw=
 connectrpc.com/connect v1.18.1/go.mod h1:0292hj1rnx8oFrStN7cB4jjVBeqs+Yx5yDIC2prWDO8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -22,6 +24,8 @@ github.com/openai/openai-go v1.5.0 h1:EcSBUYTiA4xbsO0VTX3i2WCPwKLMniwlVpiW/dCoXr
 github.com/openai/openai-go v1.5.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redpanda-data/common-go/api v0.0.0-20250801174835-9eea07f1ea06 h1:9Ecc+Cg1EyqSTIQ6wQKoKk8BqDlBQmR74bJui4qIqsM=
+github.com/redpanda-data/common-go/api v0.0.0-20250801174835-9eea07f1ea06/go.mod h1:klAmWfc8Q3hEZk8geFTMu6f2sk3VUKRS7cv/LvB05ig=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -124,7 +124,7 @@ func Register{{$key}}Handler(s *mcpserver.MCPServer, srv {{$key}}Server, opts ..
 
     resp, err := srv.{{$tool_name}}(ctx, &req)
     if err != nil {
-      return nil, err
+      return runtime.HandleError(err)
     }
 
     marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -176,7 +176,7 @@ func Register{{$key}}HandlerOpenAI(s *mcpserver.MCPServer, srv {{$key}}Server, o
 
     resp, err := srv.{{$tool_name}}(ctx, &req)
     if err != nil {
-      return nil, err
+      return runtime.HandleError(err)
     }
 
     marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -259,7 +259,7 @@ func ForwardToConnect{{$key}}Client(s *mcpserver.MCPServer, client Connect{{$key
 
     resp, err := client.{{$tool_name}}(ctx, connect.NewRequest(&req))
     if err != nil {
-      return nil, err
+      return runtime.HandleError(err)
     }
 
     marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -310,7 +310,7 @@ func ForwardTo{{$key}}Client(s *mcpserver.MCPServer, client {{$key}}Client, opts
 
     resp, err := client.{{$tool_name}}(ctx, &req)
     if err != nil {
-      return nil, err
+      return runtime.HandleError(err)
     }
 
     marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)

--- a/pkg/runtime/error.go
+++ b/pkg/runtime/error.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"errors"
+
+	"connectrpc.com/connect"
+	"github.com/mark3labs/mcp-go/mcp"
+	apierrors "github.com/redpanda-data/common-go/api/errors"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// HandleError converts a gRPC/Connect error into a structured MCP tool result
+// It extracts error codes, messages, and detailed error information using common-go utilities
+func HandleError(err error) (*mcp.CallToolResult, error) {
+	if err == nil {
+		return nil, nil
+	}
+
+	// Convert to google.rpc.Status regardless of source
+	var statusProto *spb.Status
+
+	// Try to extract gRPC status first
+	if st, ok := status.FromError(err); ok {
+		statusProto = st.Proto()
+	} else if connectErr := new(connect.Error); errors.As(err, &connectErr) {
+		// Handle Connect RPC errors using ConnectErrorToGoogleStatus
+		statusProto = apierrors.ConnectErrorToGoogleStatus(connectErr)
+	} else {
+		// Create a basic status for generic errors
+		statusProto = &spb.Status{
+			Code:    int32(codes.Unknown),
+			Message: err.Error(),
+			Details: nil,
+		}
+	}
+
+	// Use StatusToNice to convert to the common-go ErrorStatus format
+	niceStatus := apierrors.StatusToNice(statusProto)
+
+	// Marshal the niceStatus directly to JSON using protojson
+	finalJSON, marshalErr := protojson.Marshal(niceStatus)
+	if marshalErr != nil {
+		// Fallback to simple error message if JSON marshaling fails
+		return mcp.NewToolResultError("Error: " + err.Error()), nil
+	}
+
+	return mcp.NewToolResultError(string(finalJSON)), nil
+}

--- a/pkg/runtime/error_test.go
+++ b/pkg/runtime/error_test.go
@@ -1,0 +1,265 @@
+package runtime
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/mark3labs/mcp-go/mcp"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestHandleError_SimpleError(t *testing.T) {
+	err := errors.New("simple error")
+	result, handleErr := HandleError(err)
+
+	if handleErr != nil {
+		t.Fatalf("HandleError should not return an error, got: %v", handleErr)
+	}
+
+	if result == nil {
+		t.Fatal("HandleError should return a result")
+	}
+
+	// Parse the JSON error response
+	textContent := result.Content[0].(mcp.TextContent)
+	var errorResp map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(textContent.Text), &errorResp); jsonErr != nil {
+		t.Fatalf("Failed to parse error JSON: %v", jsonErr)
+	}
+
+	if errorResp["code"] != "UNKNOWN" {
+		t.Errorf("Expected code 'UNKNOWN', got: %s", errorResp["code"])
+	}
+
+	if errorResp["message"] != "simple error" {
+		t.Errorf("Expected message 'simple error', got: %s", errorResp["message"])
+	}
+}
+
+func TestHandleError_GRPCStatus(t *testing.T) {
+	// Create a gRPC status error with details
+	st := status.New(codes.InvalidArgument, "invalid request")
+
+	// Add a detail message
+	stringValue := wrapperspb.String("additional info")
+
+	st, err := st.WithDetails(stringValue)
+	if err != nil {
+		t.Fatalf("Failed to add details: %v", err)
+	}
+
+	result, handleErr := HandleError(st.Err())
+
+	if handleErr != nil {
+		t.Fatalf("HandleError should not return an error, got: %v", handleErr)
+	}
+
+	if result == nil {
+		t.Fatal("HandleError should return a result")
+	}
+
+	// Parse the JSON error response
+	textContent := result.Content[0].(mcp.TextContent)
+	var errorResp map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(textContent.Text), &errorResp); jsonErr != nil {
+		t.Fatalf("Failed to parse error JSON: %v", jsonErr)
+	}
+
+	if errorResp["code"] != "INVALID_ARGUMENT" {
+		t.Errorf("Expected code 'INVALID_ARGUMENT', got: %s", errorResp["code"])
+	}
+
+	if errorResp["message"] != "invalid request" {
+		t.Errorf("Expected message 'invalid request', got: %s", errorResp["message"])
+	}
+
+	details, hasDetails := errorResp["details"].([]interface{})
+	if !hasDetails || len(details) == 0 {
+		t.Error("Expected error details, got none")
+	}
+
+	// Verify the actual content of error details
+	if len(details) > 0 {
+		detail := details[0].(map[string]interface{})
+
+		// Check @type field
+		if typeField, ok := detail["@type"]; ok {
+			if typeStr, ok := typeField.(string); ok {
+				if typeStr != "type.googleapis.com/google.protobuf.StringValue" {
+					t.Errorf("Expected @type 'type.googleapis.com/google.protobuf.StringValue', got: %s", typeStr)
+				}
+			}
+		} else {
+			t.Error("Expected @type field in error details")
+		}
+
+		// Check value field
+		if valueField, ok := detail["value"]; ok {
+			if valueStr, ok := valueField.(string); ok {
+				if valueStr != "additional info" {
+					t.Errorf("Expected value 'additional info', got: %s", valueStr)
+				}
+			}
+		} else {
+			t.Error("Expected value field in error details")
+		}
+	}
+}
+
+func TestHandleError_ConnectError(t *testing.T) {
+	// Create a Connect error
+	connectErr := connect.NewError(connect.CodeInvalidArgument, errors.New("connect error"))
+
+	result, handleErr := HandleError(connectErr)
+
+	if handleErr != nil {
+		t.Fatalf("HandleError should not return an error, got: %v", handleErr)
+	}
+
+	if result == nil {
+		t.Fatal("HandleError should return a result")
+	}
+
+	// Parse the JSON error response
+	textContent := result.Content[0].(mcp.TextContent)
+	var errorResp map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(textContent.Text), &errorResp); jsonErr != nil {
+		t.Fatalf("Failed to parse error JSON: %v", jsonErr)
+	}
+
+	if errorResp["code"] != "INVALID_ARGUMENT" {
+		t.Errorf("Expected code 'INVALID_ARGUMENT', got: %s", errorResp["code"])
+	}
+
+	if errorResp["message"] != "connect error" {
+		t.Errorf("Expected message 'connect error', got: %s", errorResp["message"])
+	}
+}
+
+func TestHandleError_GRPCStatusWithBadRequest(t *testing.T) {
+	// Create a gRPC status error with BadRequest details
+	st := status.New(codes.InvalidArgument, "validation failed")
+
+	// Add BadRequest details with field violations
+	badRequest := &errdetails.BadRequest{
+		FieldViolations: []*errdetails.BadRequest_FieldViolation{
+			{
+				Field:       "email",
+				Description: "email is required",
+			},
+			{
+				Field:       "password",
+				Description: "password must be at least 8 characters",
+			},
+		},
+	}
+
+	st, err := st.WithDetails(badRequest)
+	if err != nil {
+		t.Fatalf("Failed to add details: %v", err)
+	}
+
+	result, handleErr := HandleError(st.Err())
+
+	if handleErr != nil {
+		t.Fatalf("HandleError should not return an error, got: %v", handleErr)
+	}
+
+	if result == nil {
+		t.Fatal("HandleError should return a result")
+	}
+
+	// Parse the JSON error response
+	textContent := result.Content[0].(mcp.TextContent)
+	var errorResp map[string]interface{}
+	if jsonErr := json.Unmarshal([]byte(textContent.Text), &errorResp); jsonErr != nil {
+		t.Fatalf("Failed to parse error JSON: %v", jsonErr)
+	}
+
+	if errorResp["code"] != "INVALID_ARGUMENT" {
+		t.Errorf("Expected code 'INVALID_ARGUMENT', got: %s", errorResp["code"])
+	}
+
+	if errorResp["message"] != "validation failed" {
+		t.Errorf("Expected message 'validation failed', got: %s", errorResp["message"])
+	}
+
+	details, hasDetails := errorResp["details"].([]interface{})
+	if !hasDetails || len(details) == 0 {
+		t.Error("Expected error details, got none")
+	}
+
+	// Verify the BadRequest error details content
+	if len(details) > 0 {
+		detail := details[0].(map[string]interface{})
+
+		// Check @type field
+		if typeField, ok := detail["@type"]; ok {
+			if typeStr, ok := typeField.(string); ok {
+				if typeStr != "type.googleapis.com/google.rpc.BadRequest" {
+					t.Errorf("Expected @type 'type.googleapis.com/google.rpc.BadRequest', got: %s", typeStr)
+				}
+			}
+		} else {
+			t.Error("Expected @type field in error details")
+		}
+
+		// Check fieldViolations field (protojson uses camelCase by default)
+		if fieldViolationsField, ok := detail["fieldViolations"]; ok {
+			if violations, ok := fieldViolationsField.([]interface{}); ok {
+				if len(violations) != 2 {
+					t.Errorf("Expected 2 field violations, got: %d", len(violations))
+				}
+
+				// Check first violation
+				if len(violations) > 0 {
+					violation := violations[0].(map[string]interface{})
+					if field, ok := violation["field"].(string); ok {
+						if field != "email" {
+							t.Errorf("Expected field 'email', got: %s", field)
+						}
+					}
+					if desc, ok := violation["description"].(string); ok {
+						if desc != "email is required" {
+							t.Errorf("Expected description 'email is required', got: %s", desc)
+						}
+					}
+				}
+
+				// Check second violation
+				if len(violations) > 1 {
+					violation := violations[1].(map[string]interface{})
+					if field, ok := violation["field"].(string); ok {
+						if field != "password" {
+							t.Errorf("Expected field 'password', got: %s", field)
+						}
+					}
+					if desc, ok := violation["description"].(string); ok {
+						if desc != "password must be at least 8 characters" {
+							t.Errorf("Expected description 'password must be at least 8 characters', got: %s", desc)
+						}
+					}
+				}
+			}
+		} else {
+			t.Error("Expected fieldViolations field in error details")
+		}
+	}
+}
+
+func TestHandleError_NilError(t *testing.T) {
+	result, handleErr := HandleError(nil)
+
+	if handleErr != nil {
+		t.Fatalf("HandleError should not return an error for nil input, got: %v", handleErr)
+	}
+
+	if result != nil {
+		t.Fatal("HandleError should return nil result for nil error")
+	}
+}

--- a/pkg/testdata/gen/go-golden/google/bytestream/bytestreammcp/bytestream.pb.mcp.go
+++ b/pkg/testdata/gen/go-golden/google/bytestream/bytestreammcp/bytestream.pb.mcp.go
@@ -63,7 +63,7 @@ func RegisterByteStreamHandler(s *mcpserver.MCPServer, srv ByteStreamServer, opt
 
 		resp, err := srv.QueryWriteStatus(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -112,7 +112,7 @@ func RegisterByteStreamHandlerOpenAI(s *mcpserver.MCPServer, srv ByteStreamServe
 
 		resp, err := srv.QueryWriteStatus(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -181,7 +181,7 @@ func ForwardToConnectByteStreamClient(s *mcpserver.MCPServer, client ConnectByte
 
 		resp, err := client.QueryWriteStatus(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -227,7 +227,7 @@ func ForwardToByteStreamClient(s *mcpserver.MCPServer, client ByteStreamClient, 
 
 		resp, err := client.QueryWriteStatus(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)

--- a/pkg/testdata/gen/go-golden/google/longrunning/longrunningpbmcp/operations.pb.mcp.go
+++ b/pkg/testdata/gen/go-golden/google/longrunning/longrunningpbmcp/operations.pb.mcp.go
@@ -76,7 +76,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.CancelOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -115,7 +115,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.DeleteOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -154,7 +154,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.GetOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -193,7 +193,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.ListOperations(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -232,7 +232,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.WaitOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -281,7 +281,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.CancelOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -322,7 +322,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.DeleteOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -363,7 +363,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.GetOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -404,7 +404,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.ListOperations(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -445,7 +445,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.WaitOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -522,7 +522,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.CancelOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -560,7 +560,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.DeleteOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -598,7 +598,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.GetOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -636,7 +636,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.ListOperations(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -674,7 +674,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.WaitOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -720,7 +720,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.CancelOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -758,7 +758,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.DeleteOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -796,7 +796,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.GetOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -834,7 +834,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.ListOperations(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -872,7 +872,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.WaitOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)

--- a/pkg/testdata/gen/go-golden/testdata/testdatamcp/test_service.pb.mcp.go
+++ b/pkg/testdata/gen/go-golden/testdata/testdatamcp/test_service.pb.mcp.go
@@ -69,7 +69,7 @@ func RegisterTestServiceHandler(s *mcpserver.MCPServer, srv TestServiceServer, o
 
 		resp, err := srv.CreateItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -108,7 +108,7 @@ func RegisterTestServiceHandler(s *mcpserver.MCPServer, srv TestServiceServer, o
 
 		resp, err := srv.GetItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -147,7 +147,7 @@ func RegisterTestServiceHandler(s *mcpserver.MCPServer, srv TestServiceServer, o
 
 		resp, err := srv.ProcessWellKnownTypes(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -196,7 +196,7 @@ func RegisterTestServiceHandlerOpenAI(s *mcpserver.MCPServer, srv TestServiceSer
 
 		resp, err := srv.CreateItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -237,7 +237,7 @@ func RegisterTestServiceHandlerOpenAI(s *mcpserver.MCPServer, srv TestServiceSer
 
 		resp, err := srv.GetItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -278,7 +278,7 @@ func RegisterTestServiceHandlerOpenAI(s *mcpserver.MCPServer, srv TestServiceSer
 
 		resp, err := srv.ProcessWellKnownTypes(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -351,7 +351,7 @@ func ForwardToConnectTestServiceClient(s *mcpserver.MCPServer, client ConnectTes
 
 		resp, err := client.CreateItem(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -389,7 +389,7 @@ func ForwardToConnectTestServiceClient(s *mcpserver.MCPServer, client ConnectTes
 
 		resp, err := client.GetItem(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -427,7 +427,7 @@ func ForwardToConnectTestServiceClient(s *mcpserver.MCPServer, client ConnectTes
 
 		resp, err := client.ProcessWellKnownTypes(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -473,7 +473,7 @@ func ForwardToTestServiceClient(s *mcpserver.MCPServer, client TestServiceClient
 
 		resp, err := client.CreateItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -511,7 +511,7 @@ func ForwardToTestServiceClient(s *mcpserver.MCPServer, client TestServiceClient
 
 		resp, err := client.GetItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -549,7 +549,7 @@ func ForwardToTestServiceClient(s *mcpserver.MCPServer, client TestServiceClient
 
 		resp, err := client.ProcessWellKnownTypes(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)

--- a/pkg/testdata/gen/go/google/bytestream/bytestreammcp/bytestream.pb.mcp.go
+++ b/pkg/testdata/gen/go/google/bytestream/bytestreammcp/bytestream.pb.mcp.go
@@ -63,7 +63,7 @@ func RegisterByteStreamHandler(s *mcpserver.MCPServer, srv ByteStreamServer, opt
 
 		resp, err := srv.QueryWriteStatus(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -112,7 +112,7 @@ func RegisterByteStreamHandlerOpenAI(s *mcpserver.MCPServer, srv ByteStreamServe
 
 		resp, err := srv.QueryWriteStatus(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -181,7 +181,7 @@ func ForwardToConnectByteStreamClient(s *mcpserver.MCPServer, client ConnectByte
 
 		resp, err := client.QueryWriteStatus(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -227,7 +227,7 @@ func ForwardToByteStreamClient(s *mcpserver.MCPServer, client ByteStreamClient, 
 
 		resp, err := client.QueryWriteStatus(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)

--- a/pkg/testdata/gen/go/google/longrunning/longrunningpbmcp/operations.pb.mcp.go
+++ b/pkg/testdata/gen/go/google/longrunning/longrunningpbmcp/operations.pb.mcp.go
@@ -76,7 +76,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.CancelOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -115,7 +115,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.DeleteOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -154,7 +154,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.GetOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -193,7 +193,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.ListOperations(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -232,7 +232,7 @@ func RegisterOperationsHandler(s *mcpserver.MCPServer, srv OperationsServer, opt
 
 		resp, err := srv.WaitOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -281,7 +281,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.CancelOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -322,7 +322,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.DeleteOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -363,7 +363,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.GetOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -404,7 +404,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.ListOperations(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -445,7 +445,7 @@ func RegisterOperationsHandlerOpenAI(s *mcpserver.MCPServer, srv OperationsServe
 
 		resp, err := srv.WaitOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -522,7 +522,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.CancelOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -560,7 +560,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.DeleteOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -598,7 +598,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.GetOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -636,7 +636,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.ListOperations(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -674,7 +674,7 @@ func ForwardToConnectOperationsClient(s *mcpserver.MCPServer, client ConnectOper
 
 		resp, err := client.WaitOperation(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -720,7 +720,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.CancelOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -758,7 +758,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.DeleteOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -796,7 +796,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.GetOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -834,7 +834,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.ListOperations(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -872,7 +872,7 @@ func ForwardToOperationsClient(s *mcpserver.MCPServer, client OperationsClient, 
 
 		resp, err := client.WaitOperation(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)

--- a/pkg/testdata/gen/go/testdata/testdatamcp/test_service.pb.mcp.go
+++ b/pkg/testdata/gen/go/testdata/testdatamcp/test_service.pb.mcp.go
@@ -69,7 +69,7 @@ func RegisterTestServiceHandler(s *mcpserver.MCPServer, srv TestServiceServer, o
 
 		resp, err := srv.CreateItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -108,7 +108,7 @@ func RegisterTestServiceHandler(s *mcpserver.MCPServer, srv TestServiceServer, o
 
 		resp, err := srv.GetItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -147,7 +147,7 @@ func RegisterTestServiceHandler(s *mcpserver.MCPServer, srv TestServiceServer, o
 
 		resp, err := srv.ProcessWellKnownTypes(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -196,7 +196,7 @@ func RegisterTestServiceHandlerOpenAI(s *mcpserver.MCPServer, srv TestServiceSer
 
 		resp, err := srv.CreateItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -237,7 +237,7 @@ func RegisterTestServiceHandlerOpenAI(s *mcpserver.MCPServer, srv TestServiceSer
 
 		resp, err := srv.GetItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -278,7 +278,7 @@ func RegisterTestServiceHandlerOpenAI(s *mcpserver.MCPServer, srv TestServiceSer
 
 		resp, err := srv.ProcessWellKnownTypes(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -351,7 +351,7 @@ func ForwardToConnectTestServiceClient(s *mcpserver.MCPServer, client ConnectTes
 
 		resp, err := client.CreateItem(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -389,7 +389,7 @@ func ForwardToConnectTestServiceClient(s *mcpserver.MCPServer, client ConnectTes
 
 		resp, err := client.GetItem(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -427,7 +427,7 @@ func ForwardToConnectTestServiceClient(s *mcpserver.MCPServer, client ConnectTes
 
 		resp, err := client.ProcessWellKnownTypes(ctx, connect.NewRequest(&req))
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp.Msg)
@@ -473,7 +473,7 @@ func ForwardToTestServiceClient(s *mcpserver.MCPServer, client TestServiceClient
 
 		resp, err := client.CreateItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -511,7 +511,7 @@ func ForwardToTestServiceClient(s *mcpserver.MCPServer, client TestServiceClient
 
 		resp, err := client.GetItem(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)
@@ -549,7 +549,7 @@ func ForwardToTestServiceClient(s *mcpserver.MCPServer, client TestServiceClient
 
 		resp, err := client.ProcessWellKnownTypes(ctx, &req)
 		if err != nil {
-			return nil, err
+			return runtime.HandleError(err)
 		}
 
 		marshaled, err = (protojson.MarshalOptions{UseProtoNames: true, EmitDefaultValues: true}).Marshal(resp)


### PR DESCRIPTION
previously we provided only code and message.

e.g. when using claude code as client: Violation error in e.g. dataplane API of redpanda cloud:

Old:
```
MCP error -32603: invalid_argument: provided parameters are invalid
```

New:
```
Error: {"code":"INVALID_ARGUMENT", "message":"provided parameters are invalid", "details":[{"@type":"google.rpc.ErrorInfo", "reason":"REASON_INVALID_INPUT", "domain":"redpanda.com/dataplane"}, 
     {"@type":"google.rpc.BadRequest", "fieldViolations":[{"field":"topic.name", "description":"value does not match regex pattern `^[a-zA-Z0-9._\\-]*$`"}]}]}
```