### PR TITLE
Add `trim_tool_prefixes` option

### DIFF
--- a/cmd/protoc-gen-go-mcp/main.go
+++ b/cmd/protoc-gen-go-mcp/main.go
@@ -27,6 +27,11 @@ func main() {
 		"mcp",
 		"Generate files into a sub-package of the package containing the base .pb.go files using the given suffix. An empty suffix denotes to generate into the same package as the base pb.go files.",
 	)
+	trimToolPrefixes := flagSet.Bool(
+		"trim_tool_prefixes",
+		false,
+		"Remove the most common leading substring from every tool name prior to mangling",
+	)
 
 	protogen.Options{
 		ParamFunc: flagSet.Set,
@@ -35,7 +40,7 @@ func main() {
 			if !f.Generate {
 				continue
 			}
-			generator.NewFileGenerator(f, gen).Generate(*packageSuffix)
+			generator.NewFileGenerator(f, gen).Generate(*packageSuffix, *trimToolPrefixes)
 		}
 		return nil
 	})

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -383,3 +383,113 @@ func TestFullGeneration(t *testing.T) {
 
 	g.Expect(err).ToNot(HaveOccurred())
 }
+
+func TestFindCommonPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		names []string
+		want  string
+	}{
+		{
+			name:  "empty slice",
+			names: []string{},
+			want:  "",
+		},
+		{
+			name:  "single name",
+			names: []string{"foo_BarService_v1_DoStuff"},
+			want:  "",
+		},
+		{
+			name:  "no common prefix",
+			names: []string{"foo_BarService_v1_DoStuff", "baz_QuxService_v2_DoOther"},
+			want:  "",
+		},
+		{
+			name:  "common prefix with underscore boundary",
+			names: []string{"foo_BarService_v1_DoStuff", "foo_BarService_v1_DoOther", "foo_BarService_v1_DoAnything"},
+			want:  "foo_BarService_v1_",
+		},
+		{
+			name:  "common prefix without underscore boundary",
+			names: []string{"foobarbaz", "foobarqux"},
+			want:  "foobar",
+		},
+		{
+			name:  "typical protobuf service names",
+			names: []string{"testdata_TestService_CreateItem", "testdata_TestService_GetItem", "testdata_TestService_ProcessWellKnownTypes"},
+			want:  "testdata_TestService_",
+		},
+		{
+			name:  "prefix too short",
+			names: []string{"a_foo", "a_bar"},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := findCommonPrefix(tt.names)
+			g.Expect(result).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestToolNameTrimming(t *testing.T) {
+	tests := []struct {
+		name              string
+		toolNames         []string
+		trimToolPrefixes  bool
+		expectedToolNames []string
+	}{
+		{
+			name:              "no trimming when disabled",
+			toolNames:         []string{"testdata_TestService_CreateItem", "testdata_TestService_GetItem"},
+			trimToolPrefixes:  false,
+			expectedToolNames: []string{"testdata_TestService_CreateItem", "testdata_TestService_GetItem"},
+		},
+		{
+			name:              "trimming when enabled",
+			toolNames:         []string{"testdata_TestService_CreateItem", "testdata_TestService_GetItem", "testdata_TestService_ProcessWellKnownTypes"},
+			trimToolPrefixes:  true,
+			expectedToolNames: []string{"CreateItem", "GetItem", "ProcessWellKnownTypes"},
+		},
+		{
+			name:              "no trimming when no common prefix",
+			toolNames:         []string{"foo_CreateItem", "bar_GetItem"},
+			trimToolPrefixes:  true,
+			expectedToolNames: []string{"foo_CreateItem", "bar_GetItem"},
+		},
+		{
+			name:              "complex prefix trimming",
+			toolNames:         []string{"com_example_service_v1_api_CreateUser", "com_example_service_v1_api_GetUser", "com_example_service_v1_api_DeleteUser"},
+			trimToolPrefixes:  true,
+			expectedToolNames: []string{"CreateUser", "GetUser", "DeleteUser"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Find common prefix
+			var commonPrefix string
+			if tt.trimToolPrefixes {
+				commonPrefix = findCommonPrefix(tt.toolNames)
+			}
+
+			// Apply trimming logic
+			var actualNames []string
+			for _, toolName := range tt.toolNames {
+				name := toolName
+				if tt.trimToolPrefixes && commonPrefix != "" && strings.HasPrefix(name, commonPrefix) {
+					name = strings.TrimPrefix(name, commonPrefix)
+				}
+				actualNames = append(actualNames, name)
+			}
+
+			g.Expect(actualNames).To(Equal(tt.expectedToolNames))
+		})
+	}
+}


### PR DESCRIPTION
This adds a `trim_tool_prefixes` option which will strip a common prefix from the tool names. Since tool names are generated from the proto, tool names might be long like `foobar_FooBarService_v1_GetQuux` and are already mangled to keep them short (and, in our case, don't even fit in the LM Studio sidebar when testing). When enabled, this option would shorten them to just `GetQuux`, which can avoid mangling and provides a nicer experience to anyone who sees the names of tools.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>